### PR TITLE
Download feature is added into asset menu item

### DIFF
--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -12,7 +12,8 @@
 					<li><%= link_to "Create Asset", new_asset_path %></li>
 					<li><a href="#">Asset Types</a></li>
 					<li><a href="#">Asset States</a></li>
-          <li><%= link_to "Assets Bulk Upload", new_asset_import_path %></li>
+          			<li><%= link_to "Assets Bulk Upload", new_asset_import_path %></li>
+          			<li><%= link_to "Download as CSV", download_assets_path(format: :csv) %></li>
 				</ul>
 			</li>
 			<li class="dropdown <% if @page=="allocations" %>active<% end %>">


### PR DESCRIPTION
Download as csv was not getting rendered on the asset type list page and the usability is also getting suffered due to the position of the link. Hence moving the link to menu for better availability. 

![download-as-csv](https://f.cloud.github.com/assets/6417646/2407437/39058f3e-aa8c-11e3-8fe6-73f8d91dae71.png)
