### PR TITLE
AN calendar date parsing fixed, while updating asset

### DIFF
--- a/app/assets/javascripts/assets.js.coffee
+++ b/app/assets/javascripts/assets.js.coffee
@@ -3,9 +3,9 @@
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 $(document).ready ->
   $("#asset_purchase_date, #asset_release_date, #asset_make_year").parent().append('<span class="add-on"><i class="icon-calendar"></i></span>')
-  $("#purchase_date").datepicker({format:'dd/mm/yyyy'})
-  $("#release_date").datepicker({format:'dd/mm/yyyy'})
-  $("#make_year").datepicker({format:'dd/mm/yyyy'})
+  $("#purchase_date").datepicker({format:'yyyy-mm-dd'})
+  $("#release_date").datepicker({format:'yyyy-mm-dd'})
+  $("#make_year").datepicker({format:'yyyy-mm-dd'})
   $(".clickable").each(() ->
     $(this).click( ()-> window.location = $(this).parent('tr').attr('url') )
   )


### PR DESCRIPTION
Date parsing fixed in the script. tested in firefox and found working. hence fixed.

![calendar_fix](https://f.cloud.github.com/assets/6417646/2421060/9baa4346-ab7c-11e3-84f8-59e247cbe69e.png)
